### PR TITLE
Geometry for basic vector graphics (#7)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = ["baryon-core"]
 [features]
 default = ["window"]
 window = ["raw-window-handle", "winit"]
+shape = ["lyon"]
 # obj, gltf
 # pass = glam, fxhash, mint, wgpu
 # factory =
@@ -30,6 +31,10 @@ required-features = ["obj"]
 [[example]]
 name = "load-gltf"
 required-features = ["gltf"]
+
+[[example]]
+name = "shapes"
+required-features = ["shape"]
 
 [dependencies.bc]
 package = "baryon-core"
@@ -50,6 +55,7 @@ obj = { version = "0.10", optional = true }
 raw-window-handle = { version = "0.3", optional = true }
 winit = { version = "0.25", optional = true }
 wgpu = "0.11"
+lyon = { version = "0.17", optional = true }
 
 [dev-dependencies]
 naga = { version = "0.6", features = ["wgsl-in"] }

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -1,0 +1,65 @@
+// https://nical.github.io/posts/lyon-intro.html
+
+use baryon::{
+    geometry::{Geometry, Streams},
+    window::{Event, Window},
+    pass, Camera, Color,
+};
+use lyon::{algorithms::aabb::bounding_rect, math::point, path::Path};
+
+fn main() {
+    let window = Window::new().title("Shape").build();
+    let mut context = pollster::block_on(baryon::Context::init().build(&window));
+    let mut scene = baryon::Scene::new();
+
+    // Build a Path.
+    let mut builder = Path::builder();
+    builder.begin(point(5.0, 5.0));
+    builder.cubic_bezier_to(point(5.0, 5.0), point(4.0, 0.0), point(0.0, 0.0));
+    builder.cubic_bezier_to(point(-6.0, 0.0), point(-6.0, 7.0), point(-6.0, 7.0));
+    builder.cubic_bezier_to(point(-6.0, 11.0), point(-3.0, 15.4), point(5.0, 19.0));
+    builder.cubic_bezier_to(point(12.0, 15.4), point(16.0, 11.0), point(16.0, 7.0));
+    builder.cubic_bezier_to(point(16.0, 7.0), point(16.0, 0.0), point(10.0, 0.0));
+    builder.cubic_bezier_to(point(7.0, 0.0), point(5.0, 5.0), point(5.0, 5.0));
+    builder.end(true);
+    let path = builder.build();
+    let bbox = bounding_rect(path.iter());
+    let shape_prototype = Geometry::shape(Streams::empty(), path).bake(&mut context);
+    scene
+        .add_entity(&shape_prototype)
+        .component(Color::RED)
+        .position(mint::Vector3 {
+            x: bbox.size.width / -4.0,
+            y: bbox.size.height / -2.0,
+            z: 0.0,
+        })
+        .build();
+
+    let camera = baryon::Camera {
+        projection: baryon::Projection::Perspective { fov_y: 70.0 },
+        depth: 1.0..100.0,
+        node: scene
+            .add_node()
+            .position([0.0f32, 0.0, -30.0].into())
+            .look_at([0f32; 3].into(), [0f32, -1.0, 0.0].into())
+            .build(),
+        background: baryon::Color(0xFF203040),
+    };
+
+    let mut pass = pass::Solid::new(
+        &pass::SolidConfig {
+            cull_back_faces: false,
+        },
+        &context,
+    );
+
+    window.run(move |event| match event {
+        Event::Resize { width, height } => {
+            context.resize(width, height);
+        }
+        Event::Draw => {
+            context.present(&mut pass, &scene, &camera);
+        }
+        _ => {}
+    })
+}

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,4 +1,6 @@
 pub mod cuboid;
+#[cfg(feature = "shape")]
+pub mod shape;
 pub mod sphere;
 
 bitflags::bitflags!(

--- a/src/geometry/shape.rs
+++ b/src/geometry/shape.rs
@@ -1,0 +1,45 @@
+use lyon::path::Path;
+use lyon::tessellation::*;
+
+// TODO is this always correct?
+fn bounding_radius(path: Path) -> f32 {
+    path.iter().fold(0.0, |accum, item| {
+        let p = item.from();
+        if p.x > accum {
+          p.x
+        } else if p.y > accum {
+            p.y
+        } else {
+            accum
+        }
+    })
+}
+
+impl super::Geometry {
+    pub fn shape(_streams: super::Streams, path: Path) -> Self {
+        let mut buffer: VertexBuffers<crate::Position, u16> = VertexBuffers::new();
+        let mut tessellator = FillTessellator::new();
+        {
+            // Compute the tessellation.
+            tessellator
+                .tessellate_path(
+                    &path,
+                    &FillOptions::default(),
+                    &mut BuffersBuilder::new(&mut buffer, |vertex: FillVertex| {
+                        let p = vertex.position();
+                        crate::Position([p.x, p.y, 0.0])
+                    }),
+                )
+                .unwrap();
+        }
+
+        let radius = bounding_radius(path);
+
+        Self {
+            positions: buffer.vertices,
+            indices: Some(buffer.indices),
+            normals: None,
+            radius,
+        }
+    }
+}


### PR DESCRIPTION
* Add basic support for scroll wheel events and cursor events

* Fix the default red and blue colors

* Use mint::Vector2 instead of [f32; 2] in pointer and scroll events.

* Support click event

* Support basic 2D vector graphics with lyon

* Remove comment